### PR TITLE
Added preset notifications.

### DIFF
--- a/config/notify.php
+++ b/config/notify.php
@@ -38,7 +38,7 @@ return [
     */
 
     'animate' => [
-        'in_class' => 'bounceInRight', // The class to use to animate the notice in.
+        'in_class'  => 'bounceInRight', // The class to use to animate the notice in.
         'out_class' => 'bounceOutRight', // The class to use to animate the notice out.
         'timeout'   => 5000 // Number of seconds before the notice disappears
     ],
@@ -65,5 +65,25 @@ return [
     */
 
     'position' => 'top-right',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Preset Messages
+    |--------------------------------------------------------------------------
+    |
+    | Define any preset messages here that can be reused.
+    |
+    */
+
+    'preset-messages' => [
+        // An example preset 'user updated' Connectify notification.
+        'user-updated' => [
+            'message' => 'The user has been updated successfully.',
+            'type'    => 'success',
+            'icon'    => 'flaticon2-check-mark',
+            'model'   => 'connect',
+            'title'   => 'User Updated',
+        ]
+    ],
 
 ];

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ An complete example:
 
 ### Type of notifications
  
-Laravel Notify actually display 4 types of notifications
+Laravel Notify actually display 5 types of notifications
 
 1. `toast` notification, who is default notification for Laravel Notify
 
@@ -124,6 +124,31 @@ smilify('success', 'You are successfully reconnected')
 
 ```php
 emotify('success', 'You are awesome, your data was successfully created')
+```
+
+#### Preset Notifications
+
+If you have a specific notification that is used across multiple different places in your system, you can define it
+as a preset notification in your config file. This makes it easier to maintain commonly used notifications in one place. 
+Read how to define preset messages in the [Config](#config) section below.
+
+As an example, to use a preset notification you have defined called 'common-notification', use the following:
+
+```php
+notify()->preset('common-notification')
+``` 
+
+You can override any of the values that are set in the config if you need to. For example, this could be useful if you 
+have a common notification across, but you want to change the icon in one particular place that it's used without having
+to manually write out a new notification.
+
+To do this, simply pass in an array that has the key of the attribute that you want to override and the value you want
+to override it with.
+
+As an example, we could override the 'title' of our 'common-notification' by using the following:
+
+```php
+notify()->preset('common-notification', ['title' => 'This is the overridden title'])
 ```
 
 ## Config
@@ -167,6 +192,29 @@ the `top-right` position is enable.
 ```php
 'position' => 'top-right',
 ```
+
+You can define preset notifications in the config file using the following structure:
+
+```php
+'preset-messages' => [
+    'user-updated' => [
+        'message' => 'The user has been updated successfully.',
+        'type'    => 'success',
+        'icon'    => 'flaticon2-check-mark',
+        'model'   => 'connect',
+        'title'   => 'User Updated',
+    ],
+    'user-deleted' => [
+        'message' => 'The user has been deleted successfully.',
+        'type'    => 'success',
+        'icon'    => 'flaticon2-check-mark',
+        'model'   => 'connect',
+        'title'   => 'User Deleted',
+    ],
+],
+```
+
+The example above shows the config for two preset notifications: 'user-updated' and 'user-deleted'.
 
 ## Change log
 

--- a/src/Exceptions/MissingPresetNotificationException.php
+++ b/src/Exceptions/MissingPresetNotificationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Mckenziearts\Notify\Exceptions;
+
+use Exception;
+
+class MissingPresetNotificationException extends Exception
+{
+}

--- a/src/LaravelNotify.php
+++ b/src/LaravelNotify.php
@@ -2,6 +2,8 @@
 
 namespace Mckenziearts\Notify;
 
+use Exception;
+use Mckenziearts\Notify\Exceptions\MissingPresetNotificationException;
 use Mckenziearts\Notify\Storage\Session;
 
 class LaravelNotify
@@ -16,7 +18,7 @@ class LaravelNotify
     /**
      * Create a new notify instance.
      *
-     * @param Session $session
+     * @param  Session  $session
      */
     public function __construct(Session $session)
     {
@@ -26,10 +28,10 @@ class LaravelNotify
     /**
      * Flash an information message.
      *
-     * @param string $message
+     * @param  string  $message
      * @return $this
      */
-    public function info(string $message) : LaravelNotify
+    public function info(string $message): LaravelNotify
     {
         $this->flash($message, 'info', 'flaticon-exclamation-1', 'toast');
 
@@ -39,10 +41,10 @@ class LaravelNotify
     /**
      * Flash a success message.
      *
-     * @param  string $message
+     * @param  string  $message
      * @return $this
      */
-    public function success(string $message) : LaravelNotify
+    public function success(string $message): LaravelNotify
     {
         $this->flash($message, 'success', 'flaticon2-check-mark', 'toast');
 
@@ -52,10 +54,10 @@ class LaravelNotify
     /**
      * Flash an error message.
      *
-     * @param  string $message
+     * @param  string  $message
      * @return $this
      */
-    public function error(string $message) : LaravelNotify
+    public function error(string $message): LaravelNotify
     {
         $this->flash($message, 'error', 'flaticon2-delete', 'toast');
 
@@ -65,10 +67,10 @@ class LaravelNotify
     /**
      * Flash a warning message.
      *
-     * @param  string $message
+     * @param  string  $message
      * @return $this
      */
-    public function warning(string $message) : LaravelNotify
+    public function warning(string $message): LaravelNotify
     {
         $this->flash($message, 'warning', 'flaticon-warning-sign', 'toast');
 
@@ -78,12 +80,12 @@ class LaravelNotify
     /**
      * Return a Connect Notification
      *
-     * @param string $type
-     * @param string $title
-     * @param string $message
+     * @param  string  $type
+     * @param  string  $title
+     * @param  string  $message
      * @return $this
      */
-    public function connect(string $type, string $title, string $message) : LaravelNotify
+    public function connect(string $type, string $title, string $message): LaravelNotify
     {
         $icon = ($type === 'success') ? 'flaticon-like' : 'flaticon-cancel';
 
@@ -95,11 +97,11 @@ class LaravelNotify
     /**
      * Return a smiley notify
      *
-     * @param string $type
-     * @param string $message
+     * @param  string  $type
+     * @param  string  $message
      * @return $this
      */
-    public function smiley(string $type, string $message) : LaravelNotify
+    public function smiley(string $type, string $message): LaravelNotify
     {
         $icon = ($type === 'success') ? '👍' : '🙅🏽‍♂';
 
@@ -111,11 +113,11 @@ class LaravelNotify
     /**
      * Return a smiley notify
      *
-     * @param string $type
-     * @param string $message
+     * @param  string  $type
+     * @param  string  $message
      * @return $this
      */
-    public function emotify(string $type, string $message) : LaravelNotify
+    public function emotify(string $type, string $message): LaravelNotify
     {
         $this->flash($message, $type, null, 'emotify');
 
@@ -125,10 +127,10 @@ class LaravelNotify
     /**
      * Return a drake notify
      *
-     * @param string $type
+     * @param  string  $type
      * @return $this
      */
-    public function drake(string $type) : LaravelNotify
+    public function drake(string $type): LaravelNotify
     {
         $icon = ($type === 'success') ? 'flaticon2-check-mark' : 'flaticon2-cross';
         $message = ($type === 'success') ? 'Success' : 'Try Again';
@@ -139,13 +141,48 @@ class LaravelNotify
     }
 
     /**
+     * Return a preset message that is defined in the config
+     * file. If you need to override any of the values, you
+     * can pass an array with the key-value pairs of what
+     * you want to override.
+     *
+     * Example: To override the 'message' variable, the array
+     *          could have the following structure:
+     *
+     *          ['message' => 'Your new message here!']
+     *
+     * @param  string  $presetName
+     * @param  array  $overrideValues
+     * @return LaravelNotify
+     * @throws Exception
+     */
+    public function preset(string $presetName, array $overrideValues = []): LaravelNotify
+    {
+        $presetValues = config('notify.preset-messages.'.$presetName);
+
+        if (!$presetValues) {
+            throw new MissingPresetNotificationException('A preset message does not exist with the name: '.$presetName);
+        }
+
+        $this->flash(
+            $overrideValues['message'] ?? $presetValues['message'],
+            $overrideValues['type'] ?? $presetValues['type'] ?? null,
+            $overrideValues['icon'] ?? $presetValues['icon'] ?? null,
+            $overrideValues['model'] ?? $presetValues['model'] ?? null,
+            $overrideValues['title'] ?? $presetValues['title'] ?? null
+        );
+
+        return $this;
+    }
+
+    /**
      * Flash a message.
      *
-     * @param  string $message
-     * @param  string|null $type
-     * @param  string|null $icon
-     * @param  string|null $model
-     * @param  string|null $title
+     * @param  string  $message
+     * @param  string|null  $type
+     * @param  string|null  $icon
+     * @param  string|null  $model
+     * @param  string|null  $title
      *
      * @return void
      */
@@ -153,10 +190,10 @@ class LaravelNotify
     {
         $notifications = [
             'message' => $message,
-            'type' => $type,
-            'icon' => $icon,
-            'model' => $model,
-            'title' => $title
+            'type'    => $type,
+            'icon'    => $icon,
+            'model'   => $model,
+            'title'   => $title
         ];
 
         $this->session->flash('notify', $notifications);


### PR DESCRIPTION
Hi,
I'm hoping that this is something you'll consider pulling in for your next release. This pull request adds the functionality for a user to define some preset notifications in the notify.php config file.

I think this would be particularly useful if you use a certain type of notification all over your application but don't want to manually write it out everytime. Instead, you can define it as a preset notification in your config file and then call it using:
```
notify()->preset('preset-notification-name')
```

That function also takes an array as a second parameter to override any of the config values that are set for if needed. It's explained a bit more in the README.md (which I've updated to explain to developers how to tap into this if they want to).

Hopefully you like what I've done. If you have any suggestions or would like me to change anything to make it more suitable for pulling in, let me know and I'll get to it right away! :)