### PR TITLE
config\notify.php - Fixed Misleading Comment

### DIFF
--- a/config/notify.php
+++ b/config/notify.php
@@ -40,7 +40,7 @@ return [
     'animate' => [
         'in_class'  => 'bounceInRight', // The class to use to animate the notice in.
         'out_class' => 'bounceOutRight', // The class to use to animate the notice out.
-        'timeout'   => 5000, // Number of seconds before the notice disappears
+        'timeout'   => 5000, // Number of milliseconds before the notice disappears.
     ],
 
     /*

--- a/resources/views/messages.blade.php
+++ b/resources/views/messages.blade.php
@@ -1,7 +1,7 @@
 @if (session()->has('notify.message'))
 
     @if (session()->get('notify.model') === 'toast')
-        <div class="alert alert-dismissible notify-alert notify-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
+        <div class="notify-alert notify-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
             <div class="notify-alert-icon"><i class="{{ session()->get('notify.icon') }}"></i></div>
             <div class="notify-alert-text">
                 <h4>{{ session()->get('notify.title') ?? session()->get('notify.type') }}</h4>
@@ -16,7 +16,7 @@
     @endif
 
     @if (session()->get('notify.model') === 'smiley')
-        <div class="alert alert-dismissible smiley-alert smiley-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
+        <div class="smiley-alert smiley-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
             <div class="smiley-icon"><span>{{ session()->get('notify.icon') }}</span></div>
             <div class="smiley-text">
                 <p><span class="title">{{ session()->get('notify.type') }}!</span> {{ session()->get('notify.message') }}</p>
@@ -39,7 +39,7 @@
     @endif
 
     @if (session()->get('notify.model') === 'connect')
-        <div class="alert alert-dismissible connectify-alert connectify-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
+        <div class="connectify-alert connectify-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
             <div class="connectify-icon">
                 <i class="flaticon-like"></i><span>{{ session()->get('notify.type') }}</span>
             </div>
@@ -58,7 +58,7 @@
     @endif
 
     @if (session()->get('notify.model') === 'emotify')
-        <div class="alert alert-dismissible emoticon-alert emoticon-{{ session()->get('notify.type') }} animated {{ config('notify.animate.in_class') }}" role="alert">
+        <div class="emoticon-alert emoticon-{{ session()->get('notify.type') }} animated {{ config('notify.animate.in_class') }}" role="alert">
             <div class="emoticon-icon"><span></span></div>
             <div class="emoticon-text">
                 <p>{{ session()->get('notify.message') }}</p>

--- a/resources/views/messages.blade.php
+++ b/resources/views/messages.blade.php
@@ -1,7 +1,7 @@
 @if (session()->has('notify.message'))
 
     @if (session()->get('notify.model') === 'toast')
-        <div class="notify-alert notify-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
+        <div class="alert alert-dismissible notify-alert notify-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
             <div class="notify-alert-icon"><i class="{{ session()->get('notify.icon') }}"></i></div>
             <div class="notify-alert-text">
                 <h4>{{ session()->get('notify.title') ?? session()->get('notify.type') }}</h4>
@@ -16,7 +16,7 @@
     @endif
 
     @if (session()->get('notify.model') === 'smiley')
-        <div class="smiley-alert smiley-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
+        <div class="alert alert-dismissible smiley-alert smiley-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
             <div class="smiley-icon"><span>{{ session()->get('notify.icon') }}</span></div>
             <div class="smiley-text">
                 <p><span class="title">{{ session()->get('notify.type') }}!</span> {{ session()->get('notify.message') }}</p>
@@ -39,7 +39,7 @@
     @endif
 
     @if (session()->get('notify.model') === 'connect')
-        <div class="connectify-alert connectify-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
+        <div class="alert alert-dismissible connectify-alert connectify-{{ session()->get('notify.type') }} {{ config('notify.theme') }} animated {{ config('notify.animate.in_class') }}" role="alert">
             <div class="connectify-icon">
                 <i class="flaticon-like"></i><span>{{ session()->get('notify.type') }}</span>
             </div>
@@ -58,7 +58,7 @@
     @endif
 
     @if (session()->get('notify.model') === 'emotify')
-        <div class="emoticon-alert emoticon-{{ session()->get('notify.type') }} animated {{ config('notify.animate.in_class') }}" role="alert">
+        <div class="alert alert-dismissible emoticon-alert emoticon-{{ session()->get('notify.type') }} animated {{ config('notify.animate.in_class') }}" role="alert">
             <div class="emoticon-icon"><span></span></div>
             <div class="emoticon-text">
                 <p>{{ session()->get('notify.message') }}</p>


### PR DESCRIPTION
config\notify.php - Fixed Misleading Comment
Changed the comment "seconds" to "milliseconds" to avoid confusion.