### PR TITLE
Increase the stacking order of laravel-notify

### DIFF
--- a/resources/views/notifications/emotify.blade.php
+++ b/resources/views/notifications/emotify.blade.php
@@ -1,5 +1,5 @@
 @if (session()->get('notify.model') === 'emotify')
-    <div class="notify fixed inset-0 flex items-end justify-end px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end">
+    <div class="z-50 notify fixed inset-0 flex items-end justify-end px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end">
         <div
             x-data="{ show: @if(session()->get('notify.model') === 'emotify') true @else false @endif }"
             x-init="setTimeout(() => { show = true }, 750)"


### PR DESCRIPTION
Add a higher z-index to laravel-notify to ensure they will appear on top always.